### PR TITLE
Add package swift

### DIFF
--- a/MediaKeyTap/NSEventExtensions.swift
+++ b/MediaKeyTap/NSEventExtensions.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Nicholas Hurden. All rights reserved.
 //
 
-import Foundation
+import AppKit
 
 extension NSEvent {
     var isKeyEvent: Bool {

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:5.1
+
+import PackageDescription
+
+let package = Package(
+    name: "MediaKeyTap",
+    targets: [
+        .target(
+            name: "MediaKeyTap",
+            path: "MediaKeyTap"
+        ),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -4,10 +4,10 @@ import PackageDescription
 
 let package = Package(
     name: "MediaKeyTap",
+    products: [
+        .library(name: "MediaKeyTap", targets: ["MediaKeyTap"]),
+    ],
     targets: [
-        .target(
-            name: "MediaKeyTap",
-            path: "MediaKeyTap"
-        ),
+        .target(name: "MediaKeyTap", path: "MediaKeyTap"),
     ]
 )


### PR DESCRIPTION
This enables MediaKeyTap to be used with Swift Package Manager.

I needed to import AppKit in the EventExtension because NSEvent is not in Foundation.